### PR TITLE
Experimental: Drop items when tool is in off-hand

### DIFF
--- a/.idea/TheWalls.iml
+++ b/.idea/TheWalls.iml
@@ -15,6 +15,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: org.bukkit:bukkit:1.15-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.postgresql:postgresql:42.2.12" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.jiangdashao:matrix-api-repo:317d4635fd" level="project" />
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.15.1-R0.1-SNAPSHOT" level="project" />
@@ -106,19 +107,22 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: fr.xephi:authme:5.6.0-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.postgresql:postgresql:42.2.15" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker-qual:3.5.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter:5.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.7.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:3.6.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.10.15" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.10.15" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:3.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.github.seeseemelk:MockBukkit-v1.16:0.5.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.junit.jupiter:junit-jupiter:5.7.0" level="project" />
-    <orderEntry type="library" name="Maven: org.junit.jupiter:junit-jupiter-api:5.7.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apiguardian:apiguardian-api:1.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.junit.platform:junit-platform-commons:1.7.0" level="project" />
-    <orderEntry type="library" name="Maven: org.junit.jupiter:junit-jupiter-params:5.7.0" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.7.0" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.junit.platform:junit-platform-engine:1.7.0" level="project" />
-    <orderEntry type="library" name="Maven: org.mockito:mockito-core:3.6.0" level="project" />
-    <orderEntry type="library" name="Maven: net.bytebuddy:byte-buddy:1.10.15" level="project" />
-    <orderEntry type="library" name="Maven: net.bytebuddy:byte-buddy-agent:1.10.15" level="project" />
-    <orderEntry type="library" name="Maven: org.objenesis:objenesis:3.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-library:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains:annotations:19.0.0" level="project" />
   </component>
 </module>

--- a/src/main/java/pl/grzegorz2047/thewalls/TheWalls.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/TheWalls.java
@@ -22,6 +22,8 @@ import pl.grzegorz2047.thewalls.commands.vote.Voter;
 import pl.grzegorz2047.thewalls.commands.walls.WallsCommand;
 import pl.grzegorz2047.thewalls.drop.BlockDrop;
 import pl.grzegorz2047.thewalls.drop.Drop;
+import pl.grzegorz2047.thewalls.drop.ExperienceDrop;
+import pl.grzegorz2047.thewalls.drop.ItemDrop;
 import pl.grzegorz2047.thewalls.listeners.*;
 import pl.grzegorz2047.thewalls.playerclass.ClassManager;
 import pl.grzegorz2047.thewalls.scoreboard.ScoreboardAPI;
@@ -159,7 +161,7 @@ public class TheWalls extends JavaPlugin {
                     }
                 }
                 int chanceVal = prepareChance(chance);
-                Drop drop = instantiateDrop(materialDrop, tools, message, quantity, isExp, chanceVal);
+                Drop drop = createDrop(materialDrop, tools, message, quantity, isExp, chanceVal);
                 dropsList.add(drop);
             }
             dropsMap.put(materialItem, new BlockDrop(materialItem, dropsList));
@@ -178,15 +180,12 @@ public class TheWalls extends JavaPlugin {
         return chanceVal;
     }
 
-    private Drop instantiateDrop(Material materialDrop, List<String> tools, String message, int quantity, boolean isExp, int chanceVal) {
-        Drop drop;
+    private Drop createDrop(Material materialDrop, List<String> tools, String message, int quantity, boolean isExp, int chanceVal) {
         if (isExp) {
-
-            drop = new Drop(tools, quantity, chanceVal);
+            return new ExperienceDrop(tools, quantity, chanceVal);
         } else {
-            drop = new Drop(materialDrop, tools, quantity, chanceVal, message);
+            return new ItemDrop(materialDrop, tools, quantity, chanceVal, message);
         }
-        return drop;
     }
 
     private void registerListeners(PluginManager pluginManager, String loadedMotd, Map<Material, BlockDrop> dropsMap, ClassManager classManager, StorageProtection storageProtection) {
@@ -207,7 +206,7 @@ public class TheWalls extends JavaPlugin {
         pluginManager.registerEvents(new InventoryClick(), this);
         pluginManager.registerEvents(new ChooseItem(messageManager, gameData, shopMenuManager, scoreboardAPI, this.getShopManager(), classManager, gameUsers), this);
         pluginManager.registerEvents(new PlayerInteract(gameData, messageManager, shopMenuManager, classManager, storageProtection, gameUsers, scoreboardAPI), this);
-        pluginManager.registerEvents(new ItemDrop(gameData), this);
+        pluginManager.registerEvents(new ItemDropWatcher(gameData), this);
         pluginManager.registerEvents(new ServerMotd(gameData, loadedMotd), this);
 
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");

--- a/src/main/java/pl/grzegorz2047/thewalls/TheWalls.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/TheWalls.java
@@ -160,7 +160,7 @@ public class TheWalls extends JavaPlugin {
                         message = (String) propsValue;
                     }
                 }
-                int chanceVal = prepareChance(chance);
+                int chanceVal = chance != 0 ? chance : 100;
                 Drop drop = createDrop(materialDrop, tools, message, quantity, isExp, chanceVal);
                 dropsList.add(drop);
             }
@@ -168,16 +168,6 @@ public class TheWalls extends JavaPlugin {
 
         }
         return dropsMap;
-    }
-
-    private int prepareChance(int chance) {
-        int chanceVal;
-        if (chance == 0) {
-            chanceVal = 100;
-        } else {
-            chanceVal = chance;
-        }
-        return chanceVal;
     }
 
     private Drop createDrop(Material materialDrop, List<String> tools, String message, int quantity, boolean isExp, int chanceVal) {

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/BlockDrop.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/BlockDrop.java
@@ -31,7 +31,7 @@ public class BlockDrop {
             int chance = drop.getChance();
             int randomNumber = r.nextInt(100);
             if (randomNumber <= chance) {
-                if (drop.isExp()) {
+                if (drop instanceof ExperienceDrop) {
                     e.setExpToDrop(drop.getQuantity());
                 } else {
                     e.setExpToDrop(0);

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/BlockDrop.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/BlockDrop.java
@@ -5,13 +5,17 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import static pl.grzegorz2047.thewalls.api.util.ColoringUtil.colorText;
+
 public class BlockDrop {
+
+    private final Random random = new Random();
     private final Material material;
     private final List<Drop> drops;
 
@@ -21,15 +25,19 @@ public class BlockDrop {
     }
 
     public void dropItems(BlockBreakEvent e) {
-        boolean chosen = false;
-        Random r = new Random();
+
+        PlayerInventory playerInv = e.getPlayer().getInventory();
+        ItemStack itemInMainHand = playerInv.getItemInMainHand();
+        ItemStack itemInOffHand = playerInv.getItemInOffHand();
+
         for (Drop drop : drops) {
-            ItemStack itemInHand = e.getPlayer().getItemInHand();
-            if (!drop.withProperTool(itemInHand)) {
+
+            if (!drop.isProperTool(itemInMainHand) && !drop.isProperTool(itemInOffHand)) {
                 continue;
             }
+
             int chance = drop.getChance();
-            int randomNumber = r.nextInt(100);
+            int randomNumber = random.nextInt(100);
             if (randomNumber <= chance) {
                 if (drop instanceof ExperienceDrop) {
                     e.setExpToDrop(drop.getQuantity());
@@ -38,12 +46,13 @@ public class BlockDrop {
                     Location location = e.getBlock().getLocation();
                     e.getBlock().setType(Material.AIR);
                     location.getWorld().dropItemNaturally(location, drop.toItemStack());
-                    e.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', drop.getMessage()));
+                    e.getPlayer().sendMessage(colorText(drop.getMessage()));
                     e.setCancelled(true);
                 }
                 break;
             }
         }
+
         Collections.shuffle(drops);
     }
 }

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/Drop.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/Drop.java
@@ -1,37 +1,17 @@
 package pl.grzegorz2047.thewalls.drop;
 
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
 
-public class Drop {
-    private final List<String> tools;
-    private Material material;
-    private String message = "";
-    private boolean isExp = false;
-    private int quantity;
-    private int chance;
+/**
+ * An abstract reward for breaking a specific block.
+ */
+public abstract class Drop {
 
-    public Drop(List<String> tools, int quantity, int chance) {
-        this.tools = tools;
-        this.quantity = quantity;
-        this.chance = chance;
-        isExp = true;
-        material = Material.COBBLESTONE;
-    }
-
-    public Drop(Material material, List<String> tools, int quantity, int chanceVal, String message) {
-        this.material = material;
-        this.tools = tools;
-        this.quantity = quantity;
-        this.chance = chanceVal;
-        this.message = message;
-    }
-
-    public boolean isExp() {
-        return this.isExp;
-    }
+    protected List<String> tools;
+    protected int quantity;
+    protected int chance;
 
     public int getQuantity() {
         return this.quantity;
@@ -54,11 +34,10 @@ public class Drop {
         }
     }
 
-    public ItemStack toItemStack() {
-        return new ItemStack(material, quantity);
-    }
+    public abstract String getMessage();
 
-    public String getMessage() {
-        return message;
-    }
+    /**
+     * Creates a new item stack described by this Drop, if applicable.
+     */
+    public abstract ItemStack toItemStack();
 }

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/Drop.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/Drop.java
@@ -21,7 +21,7 @@ public abstract class Drop {
         return this.chance;
     }
 
-    public boolean withProperTool(ItemStack item) {
+    public boolean isProperTool(ItemStack item) {
         boolean isAny = this.tools.stream().anyMatch(x -> x.equals("ANY"));
         if (isAny) {
             return true;

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/ExperienceDrop.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/ExperienceDrop.java
@@ -1,0 +1,26 @@
+package pl.grzegorz2047.thewalls.drop;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * A drop that results in experience orbs being awarded to the player.
+ */
+public final class ExperienceDrop extends Drop {
+
+    public ExperienceDrop(List<String> tools, int quantity, int chance) {
+        this.tools = tools;
+        this.quantity = quantity;
+        this.chance = chance;
+    }
+
+    public String getMessage() {
+        return "";
+    }
+
+    public ItemStack toItemStack() {
+        return new ItemStack(Material.COBBLESTONE, quantity);
+    }
+}

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/ItemDrop.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/ItemDrop.java
@@ -1,0 +1,31 @@
+package pl.grzegorz2047.thewalls.drop;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * A drop variant that results in an item being awarded to the player.
+ */
+public final class ItemDrop extends Drop {
+
+    private final Material material;
+    private final String message;
+
+    public ItemDrop(Material material, List<String> tools, int quantity, int chanceVal, String message) {
+        this.material = material;
+        this.tools = tools;
+        this.quantity = quantity;
+        this.chance = chanceVal;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public ItemStack toItemStack() {
+        return new ItemStack(material, quantity);
+    }
+}

--- a/src/main/java/pl/grzegorz2047/thewalls/drop/ItemTool.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/drop/ItemTool.java
@@ -1,7 +1,0 @@
-package pl.grzegorz2047.thewalls.drop;
-
-import org.bukkit.Material;
-
-public enum ItemTool {
-
-}

--- a/src/main/java/pl/grzegorz2047/thewalls/listeners/ItemDropWatcher.java
+++ b/src/main/java/pl/grzegorz2047/thewalls/listeners/ItemDropWatcher.java
@@ -8,20 +8,18 @@ import pl.grzegorz2047.thewalls.GameData;
 /**
  * Created by grzeg on 22.05.2016.
  */
-public class ItemDrop implements Listener {
-
+public class ItemDropWatcher implements Listener {
 
     private final GameData gameData;
 
-    public ItemDrop(GameData gameData) {
+    public ItemDropWatcher(GameData gameData) {
         this.gameData = gameData;
     }
 
     @EventHandler
-    private void onDrop(PlayerDropItemEvent e){
-        if(!gameData.isStatus(GameData.GameStatus.INGAME)){
+    private void onDrop(PlayerDropItemEvent e) {
+        if (!gameData.isStatus(GameData.GameStatus.INGAME)) {
             e.setCancelled(true);
         }
     }
-
 }

--- a/src/test/java/pl/grzegorz2047/thewalls/drop/BlockDropTest.java
+++ b/src/test/java/pl/grzegorz2047/thewalls/drop/BlockDropTest.java
@@ -1,0 +1,85 @@
+package pl.grzegorz2047.thewalls.drop;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
+import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import com.google.common.collect.ImmutableList;
+import org.bukkit.Material;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BlockDropTest {
+
+    private static ServerMock serverMock;
+
+    @BeforeAll
+    static void setup() {
+        serverMock = MockBukkit.mock();
+    }
+
+    @Test
+    void blockDropsOnlyWhenCorrectToolIsUsed() {
+
+        // Create a new drop of a single diamond with 100% chance to appear
+        String message = "SUCCESS";
+        Drop drop = new ItemDrop(Material.DIAMOND, ImmutableList.of("APPLE"), 1, 100, message);
+        BlockDrop blockDrop = new BlockDrop(null, ImmutableList.of(drop));
+
+        // Set up a mock world
+        PlayerMock player = serverMock.addPlayer();
+        assertNotNull(player.getInventory());
+        assertFalse(drop.isProperTool(player.getInventory().getItemInMainHand()));
+        assertFalse(drop.isProperTool(player.getInventory().getItemInOffHand()));
+        WorldMock world = serverMock.addSimpleWorld("test");
+        BlockMock block = world.getBlockAt(0, 2, 0);
+        assertFalse(block.getType().isAir());
+
+        // Player does not have a correct tool equipped yet
+        BlockBreakEvent event;
+        event = new BlockBreakEvent(block, player);
+        blockDrop.dropItems(event);
+        assertNull(player.nextMessage());
+
+        // Player has the tool equipped in main hand
+        player.getInventory().setItemInMainHand(new ItemStack(Material.APPLE));
+        event = new BlockBreakEvent(block, player);
+        blockDrop.dropItems(event);
+        assertEquals(message, player.nextMessage());
+
+        // Player has the tool equipped in off hand
+        player.getInventory().setItemInMainHand(new ItemStack(Material.CORNFLOWER));
+        player.getInventory().setItemInOffHand(new ItemStack(Material.APPLE));
+        event = new BlockBreakEvent(block, player);
+        blockDrop.dropItems(event);
+        assertEquals(message, player.nextMessage());
+
+        // Player no longer has the correct tool equipped
+        player.getInventory().setItemInOffHand(new ItemStack(Material.BLUE_DYE));
+        event = new BlockBreakEvent(block, player);
+        blockDrop.dropItems(event);
+        assertNull(player.nextMessage());
+
+        // Two diamonds should have spawned by now
+        assertEquals(2, world.getEntities().stream()
+            .filter(entity -> entity instanceof ItemEntityMock)
+            .filter(mock -> ((ItemEntityMock)mock).getItemStack().getType().equals(Material.DIAMOND))
+            .count());
+    }
+
+    @AfterAll
+    static void clean() {
+        MockBukkit.unmock();
+        serverMock = null;
+    }
+}


### PR DESCRIPTION
While I was toying around with the drop system to make it a bit more readable, I noticed that the checks there are only influenced by item in the main hand (pre-1.9: the only hand). So I went ahead and changed that too.

Though I've written a test suite for that, it should really be tested in-game (first example would be using two different pickaxes for valuable ores, so that the better one does not lose durability. I don't know if this would be a major thing to care about).

Oh, and the test is using the MockBukkit framework we talked about previously.